### PR TITLE
Add Base URL

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,7 +6,8 @@ from utils.doc_handler import process_documents
 from sentence_transformers import CrossEncoder
 import torch
 
-OLLAMA_API_URL = "http://localhost:11434/api/generate"
+OLLAMA_BASE_URL = "http://localhost:11434"
+OLLAMA_API_URL = f"{OLLAMA_BASE_URL}/api/generate"
 MODEL="deepseek-r1:7b"                                                      #Make sure you have it installed in ollama
 EMBEDDINGS_MODEL = "nomic-embed-text:latest"
 CROSS_ENCODER_MODEL = "cross-encoder/ms-marco-MiniLM-L-6-v2"
@@ -56,7 +57,7 @@ with st.sidebar:                                                                
     
     if uploaded_files and not st.session_state.documents_loaded:
         with st.spinner("Processing documents..."):
-            process_documents(uploaded_files,reranker,EMBEDDINGS_MODEL)
+            process_documents(uploaded_files,reranker,EMBEDDINGS_MODEL, OLLAMA_BASE_URL)
             st.success("Documents processed!")
     
     st.markdown("---")

--- a/utils/doc_handler.py
+++ b/utils/doc_handler.py
@@ -11,7 +11,7 @@ import os
 import re
 
 
-def process_documents(uploaded_files,reranker,embedding_model):
+def process_documents(uploaded_files,reranker,embedding_model, base_url):
     if st.session_state.documents_loaded:
         return
 
@@ -54,7 +54,7 @@ def process_documents(uploaded_files,reranker,embedding_model):
     text_contents = [doc.page_content for doc in texts]
 
     # 🚀 Hybrid Retrieval Setup
-    embeddings = OllamaEmbeddings(model=embedding_model)
+    embeddings = OllamaEmbeddings(model=embedding_model, base_url=base_url)
     
     # Vector store
     vector_store = FAISS.from_documents(texts, embeddings)


### PR DESCRIPTION
This PR adds base url support.

Previously, `OllamaEmbeddings` defaulted to `localhost` even if `OLLAMA_API_URL`.

This allows server hosted ollama to work.