### PR TITLE
Adding dockerfile and support to load ollama host and model from env vars

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+# Below is a sample .env file with placeholders for your environment variables specific to OLLAMA_API_URL and MODEL. You need to replace these placeholder values with actual ones based on your configuration or settings in Docker, etc. 
+OLLAMA_API_URL=http://localhost:11434/api/generate
+MODEL=deepseek-r1:7b

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,16 @@
 # Use an official Python runtime as a parent image (change 'buster' to 'slim', if needed)
-FROM python:3.9-buster  # You can adjust the version according to your requirements or base on what is available in Docker Hub for Python images.
-LABEL maintainer="your_name@example.com"  # Replace with actual contact information, GitHub profile URL, etc., using LABEL instruction (optional).
+FROM python:3.11-buster  
 
-WORKDIR /usr/src/app  # Set the working directory inside the container to where your app will be installed and run from.
+LABEL maintainer="your_name@example.com"  
 
-COPY requirements.txt ./  # Copy over any dependencies file needed for installation of Python packages within this folder in Docker image.
-RUN pip install --no-cache-dir -r requirements.txt  # Install any necessary Python package(s) listed as dependencies by running a single command on the list inside 'requirements.txt'.
+WORKDIR /usr/src/app  
 
-COPY . .  # Copy everything else from your current directory into the container's working directory (e.g., app files, etc.).
+COPY requirements.txt ./  
+RUN pip install --no-cache-dir -r requirements.txt  
 
-EXPOSE 8501  # Expose port for Streamlit app, which is defaulted here but can be changed depending upon your application setup.
+COPY . .  
 
-CMD ["streamlit", "run", "app.py"]  # This tells Docker what to run when starting up our image using docker run command later on after building it with 'docker build -t chatbot .'.
+EXPOSE 8501  
+
+CMD ["streamlit", "run", "app.py"]  
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# Use an official Python runtime as a parent image (change 'buster' to 'slim', if needed)
+FROM python:3.9-buster  # You can adjust the version according to your requirements or base on what is available in Docker Hub for Python images.
+LABEL maintainer="your_name@example.com"  # Replace with actual contact information, GitHub profile URL, etc., using LABEL instruction (optional).
+
+WORKDIR /usr/src/app  # Set the working directory inside the container to where your app will be installed and run from.
+
+COPY requirements.txt ./  # Copy over any dependencies file needed for installation of Python packages within this folder in Docker image.
+RUN pip install --no-cache-dir -r requirements.txt  # Install any necessary Python package(s) listed as dependencies by running a single command on the list inside 'requirements.txt'.
+
+COPY . .  # Copy everything else from your current directory into the container's working directory (e.g., app files, etc.).
+
+EXPOSE 8501  # Expose port for Streamlit app, which is defaulted here but can be changed depending upon your application setup.
+
+CMD ["streamlit", "run", "app.py"]  # This tells Docker what to run when starting up our image using docker run command later on after building it with 'docker build -t chatbot .'.
+

--- a/app.py
+++ b/app.py
@@ -6,6 +6,9 @@ from utils.doc_handler import process_documents
 from sentence_transformers import CrossEncoder
 import torch
 import os
+from dotenv import load_dotenv, find_dotenv
+
+load_dotenv(find_dotenv())  # Loads .env file contents into the application based on key-value pairs defined therein, making them accessible via 'os' module functions like os.getenv().
 
 OLLAMA_API_URL = os.getenv("OLLAMA_API_URL", "http://localhost:11434/api/generate")  # Get environment variable, if not available use current value in script. "http://localhost:11434/api/generate"
 MODEL= os.getenv("MODEL", "deepseek-r1:7b")                                                      #Make sure you have it installed in ollama

--- a/app.py
+++ b/app.py
@@ -5,9 +5,10 @@ from utils.retriever_pipeline import retrieve_documents
 from utils.doc_handler import process_documents
 from sentence_transformers import CrossEncoder
 import torch
+import os
 
-OLLAMA_API_URL = "http://localhost:11434/api/generate"
-MODEL="deepseek-r1:7b"                                                      #Make sure you have it installed in ollama
+OLLAMA_API_URL = os.getenv("OLLAMA_API_URL", "http://localhost:11434/api/generate")  # Get environment variable, if not available use current value in script. "http://localhost:11434/api/generate"
+MODEL= os.getenv("MODEL", "deepseek-r1:7b")                                                      #Make sure you have it installed in ollama
 EMBEDDINGS_MODEL = "nomic-embed-text:latest"
 CROSS_ENCODER_MODEL = "cross-encoder/ms-marco-MiniLM-L-6-v2"
 


### PR DESCRIPTION
With this MR i have introduced the possibility to configure the Ollama Host and the desired chat model to use via environment variables.

I've also added a Dockerfile because it's just better :) 

TODO:

1. Update README
2. Add docker-compose