### PR TITLE
Update .env to match installation instructions

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 # Below is a sample .env file with placeholders for your environment variables specific to OLLAMA_API_URL and MODEL. You need to replace these placeholder values with actual ones based on your configuration or settings in Docker, etc. 
 OLLAMA_API_URL=http://127.0.0.1:11434
-MODEL=hf.co/bartowski/DeepSeek-R1-Distill-Qwen-14B-GGUF:Q4_K_M
+MODEL=deepseek-r1:7b


### PR DESCRIPTION
Model mismatch in .env

Instructions were for ollama to pull deepseek-r1:7b, but .env was set for another model.