### PR TITLE
feat: Add install script and switch to Qwen3-1.7B model

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,52 @@ This chatbot enables **fast, accurate, and explainable retrieval of information*
 
 # **Installation & Setup**
 
-You can install and run the **DeepSeek RAG Chatbot** in one of two ways:
+There are a few ways to install and run the **DeepSeek RAG Chatbot**:
 
-1. **Traditional (Python/venv) Installation**  
-2. **Docker Installation** (ideal for containerized deployments)
+1. **Simplified Installation (Recommended using `install.sh`)**
+2. **Traditional (Manual Python/venv) Installation**
+3. **Docker Installation** (ideal for containerized deployments)
 
 ---
 
-## **1️⃣ Traditional (Python/venv) Installation**
+## **1️⃣ Simplified Installation (Recommended using `install.sh`)**
+
+This is the easiest way to get started. The `install.sh` script automates the setup process.
+
+1.  **Clone the Repository:**
+    ```bash
+    git clone https://github.com/SaiAkhil066/DeepSeek-RAG-Chatbot.git
+    cd DeepSeek-RAG-Chatbot
+    ```
+
+2.  **Run the Installation Script:**
+    Make sure the script is executable, then run it:
+    ```bash
+    chmod +x install.sh
+    ./install.sh
+    ```
+    This script will:
+    *   Check for Ollama and install it if it's not found.
+    *   Install Python dependencies from `requirements.txt`.
+    *   Create or update a `.env` file with the necessary environment variables, including the model `huihui-ai/Qwen3-1.7B-abliterated`.
+    *   Pull the specified Ollama model.
+
+3.  **Activate Environment Variables:**
+    After the script completes, source the `.env` file to load the environment variables into your current shell session:
+    ```bash
+    source .env
+    ```
+
+4.  **Run the Chatbot:**
+    Launch the Streamlit app:
+    ```bash
+    streamlit run app.py
+    ```
+    Open your browser at **[http://localhost:8501](http://localhost:8501)** to access the chatbot UI.
+
+---
+
+## **2️⃣ Traditional (Manual Python/venv) Installation**
 
 ### **Step A: Clone the Repository & Install Dependencies**
 ```
@@ -53,10 +91,10 @@ pip install -r requirements.txt
 1. **Download Ollama** → [https://ollama.com/](https://ollama.com/)  
 2. **Pull the required models**:
    ```
-   ollama pull deepseek-r1:7b
+   ollama pull huihui-ai/Qwen3-1.7B-abliterated 
    ollama pull nomic-embed-text
    ```
-   *Note: If you want to use a different model, update `MODEL` or `EMBEDDINGS_MODEL` in your environment variables or `.env` file accordingly.*
+   *Note: The `install.sh` script handles model pulling automatically. If installing manually and you want to use a different model, update `MODEL` or `EMBEDDINGS_MODEL` in your environment variables or create a `.env` file accordingly.*
 
 ### **Step C: Run the Chatbot**
 1. Make sure **Ollama** is running on your system:
@@ -104,7 +142,7 @@ services:
       - "8501:8501"
     environment:
       - OLLAMA_API_URL=http://ollama:11434
-      - MODEL=deepseek-r1:7b
+      - MODEL=huihui-ai/Qwen3-1.7B-abliterated
       - EMBEDDINGS_MODEL=nomic-embed-text:latest
       - CROSS_ENCODER_MODEL=cross-encoder/ms-marco-MiniLM-L-6-v2
     depends_on:

--- a/app.py
+++ b/app.py
@@ -12,7 +12,7 @@ load_dotenv(find_dotenv())  # Loads .env file contents into the application base
 
 OLLAMA_BASE_URL = os.getenv("OLLAMA_API_URL", "http://localhost:11434")
 OLLAMA_API_URL = f"{OLLAMA_BASE_URL}/api/generate"
-MODEL= os.getenv("MODEL", "deepseek-r1:7b")                                                      #Make sure you have it installed in ollama
+MODEL= os.getenv("MODEL", "huihui-ai/Qwen3-1.7B-abliterated")                                                      #Make sure you have it installed in ollama
 EMBEDDINGS_MODEL = "nomic-embed-text:latest"
 CROSS_ENCODER_MODEL = "cross-encoder/ms-marco-MiniLM-L-6-v2"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     # Or define them inline:
     environment:
       - OLLAMA_API_URL=http://host.docker.internal:11434
-      - MODEL=deepseek-r1:7b
+      - MODEL=huihui-ai/Qwen3-1.7B-abliterated
       - EMBEDDINGS_MODEL=nomic-embed-text:latest
       - CROSS_ENCODER_MODEL=cross-encoder/ms-marco-MiniLM-L-6-v2
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+
+# Exit immediately if a command exits with a non-zero status.
+set -e
+
+# Function to print error messages
+error_exit() {
+  echo "Error: $1" >&2
+  exit 1
+}
+
+# 1. Check for existing Ollama installation
+if ! command -v ollama &> /dev/null
+then
+    echo "Ollama not found. Installing Ollama..."
+    curl -fsSL https://ollama.com/install.sh | sh || error_exit "Ollama installation failed."
+    echo "Ollama installed successfully."
+else
+    echo "Ollama is already installed."
+fi
+
+# 2. Install Python dependencies
+echo "Installing Python dependencies..."
+if ! command -v pip &> /dev/null && ! command -v pip3 &> /dev/null; then
+    echo "pip is not installed. Please install it using your system's package manager."
+    echo "For example, on Debian/Ubuntu, you can use: sudo apt install python3-pip"
+    error_exit "pip not found."
+fi
+
+# Try pip3 first, then pip
+PIP_COMMAND=""
+if command -v pip3 &> /dev/null; then
+    PIP_COMMAND="pip3"
+elif command -v pip &> /dev/null; then
+    PIP_COMMAND="pip"
+else
+    # This case should ideally be caught by the check above, but as a fallback:
+    echo "pip is not installed. Please install it using your system's package manager."
+    echo "For example, on Debian/Ubuntu, you can use: sudo apt install python3-pip"
+    error_exit "pip not found."
+fi
+
+if [ -f "requirements.txt" ]; then
+    $PIP_COMMAND install -r requirements.txt || error_exit "Failed to install Python dependencies from requirements.txt."
+    echo "Python dependencies installed successfully."
+else
+    echo "requirements.txt not found. Skipping Python dependency installation."
+fi
+
+# 3. Set Environment Variables
+echo "Setting environment variables in .env file..."
+ENV_FILE=".env"
+OLLAMA_API_URL="OLLAMA_API_URL=http://localhost:11434"
+MODEL="MODEL=huihui-ai/Qwen3-1.7B-abliterated"
+
+# Create .env file if it doesn't exist
+touch $ENV_FILE
+
+# Update or add OLLAMA_API_URL
+if grep -q "^OLLAMA_API_URL=" "$ENV_FILE"; then
+    sed -i "s|^OLLAMA_API_URL=.*|$OLLAMA_API_URL|" "$ENV_FILE"
+else
+    echo "$OLLAMA_API_URL" >> "$ENV_FILE"
+fi
+
+# Update or add MODEL
+if grep -q "^MODEL=" "$ENV_FILE"; then
+    sed -i "s|^MODEL=.*|$MODEL|" "$ENV_FILE"
+else
+    echo "$MODEL" >> "$ENV_FILE"
+fi
+echo ".env file updated successfully."
+
+# 4. Pull the Ollama model
+echo "Pulling Ollama model: huihui-ai/Qwen3-1.7B-abliterated..."
+if command -v ollama &> /dev/null; then
+    ollama pull huihui-ai/Qwen3-1.7B-abliterated || error_exit "Failed to pull Ollama model."
+    echo "Ollama model pulled successfully."
+else
+    error_exit "Ollama command not found. Cannot pull model."
+fi
+
+# 5. Provide Execution Instructions
+echo ""
+echo "Installation and setup complete!"
+echo "To activate the environment variables, run:"
+echo "  source .env"
+echo ""
+echo "Then, you can run the application, for example:"
+echo "  streamlit run app.py"
+echo ""
+
+# 6. Make the script executable (This step will be done by the user or a separate command)
+# However, we can inform the user.
+echo "Note: If you haven't already, make this script executable by running:"
+echo "  chmod +x install.sh"
+
+exit 0


### PR DESCRIPTION
This commit introduces an `install.sh` script to simplify the setup process on Linux Debian/Pop-OS. The script handles:
- Ollama installation
- Python dependency installation via pip
- .env file creation/update with necessary environment variables
- Pulling the specified Ollama model

The default model has been changed from `deepseek-r1:7b` to `huihui-ai/Qwen3-1.7B-abliterated` in `app.py` and `docker-compose.yml`.

The README.md has been updated to include instructions for the new installation script and reflects the model change in other relevant sections.